### PR TITLE
Questionable image merging for Flux-Kontext

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "https-proxy-agent": "^5.0.1",
     "jest": "^29.7.0",
     "multer": "1.4.5-lts.2",
-    "google-auth-library": "^9.0.0"
+    "google-auth-library": "^9.0.0",
+    "canvas": "^2.11.2",
+    "sharp": "^0.33.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.3",

--- a/src/services/imageHelpers.js
+++ b/src/services/imageHelpers.js
@@ -1,4 +1,6 @@
 import { readFile } from 'fs/promises';
+import { createCanvas, loadImage } from 'canvas';
+import sharp from 'sharp';
 
 // Helper function to convert an object to FormData
 export function objectToFormData(obj) {
@@ -74,5 +76,116 @@ export function getGeminiApiKey(model) {
         return geminiKeyArray[Math.floor(Math.random() * geminiKeyArray.length)]
     } else {
         return geminiKeyArray[0]
+    }
+}
+
+// Helper function to calculate resize dimensions maintaining aspect ratio
+function calculateResizeDimensions(originalWidth, originalHeight, maxSize = 1024) {
+    const aspectRatio = originalWidth / originalHeight
+    
+    if (originalWidth > originalHeight) {
+        // Landscape orientation
+        const newWidth = Math.min(originalWidth, maxSize)
+        const newHeight = Math.round(newWidth / aspectRatio)
+        return { width: newWidth, height: newHeight }
+    } else {
+        // Portrait or square orientation
+        const newHeight = Math.min(originalHeight, maxSize)
+        const newWidth = Math.round(newHeight * aspectRatio)
+        return { width: newWidth, height: newHeight }
+    }
+}
+
+// Function to merge multiple images into a single image
+export async function mergeImages(imageFiles) {
+    if (!Array.isArray(imageFiles) || imageFiles.length === 0) {
+        throw new Error('No images to merge')
+    }
+    
+    if (imageFiles.length === 1) {
+        // If only one image, just process it normally but resize to max 1024
+        const file = imageFiles[0]
+        const buffer = await readFile(file.path)
+        
+        // Resize the single image to max 1024 resolution
+        const resizedBuffer = await sharp(file.path)
+            .resize(1024, 1024, { 
+                fit: 'inside',
+                withoutEnlargement: true 
+            })
+            .png()
+            .toBuffer()
+        
+        return {
+            blob: new Blob([resizedBuffer], { type: 'image/png' }),
+            filename: file.originalname
+        }
+    }
+    
+    // Load and resize all images using sharp for preprocessing and canvas for final processing
+    const images = []
+    for (const file of imageFiles) {
+        console.log(`Processing image: ${file.originalname}, path: ${file.path}, mimetype: ${file.mimetype}`)
+        
+        try {
+            // Resize all images to exactly 1024x1024 to eliminate whitespace
+            // This will crop/stretch images to fit perfectly
+            const pngBuffer = await sharp(file.path)
+                .resize(1024, 1024, { 
+                    fit: 'cover',  // This will crop to fill the entire 1024x1024 space
+                    position: 'center'
+                })
+                .png()
+                .toBuffer()
+            
+            console.log(`Resized and converted ${file.originalname} to 1024x1024 PNG using sharp`)
+            
+            // Load the PNG buffer with canvas
+            const image = await loadImage(pngBuffer)
+            console.log(`Successfully loaded converted image: ${file.originalname}`)
+            images.push(image)
+            
+        } catch (error) {
+            console.error(`Failed to process image ${file.originalname}:`, error.message)
+            throw new Error(`Unable to process image: ${file.originalname}. ${error.message}`)
+        }
+    }
+    
+    // Calculate dimensions for the merged image
+    // We'll arrange images in a grid layout
+    const cols = Math.ceil(Math.sqrt(images.length))
+    const rows = Math.ceil(images.length / cols)
+    
+    // Since all images are now exactly 1024x1024, no whitespace between them
+    const cellSize = 1024
+    
+    const canvasWidth = cellSize * cols
+    const canvasHeight = cellSize * rows
+    
+    // Create canvas and context
+    const canvas = createCanvas(canvasWidth, canvasHeight)
+    const ctx = canvas.getContext('2d')
+    
+    // Fill background with white
+    ctx.fillStyle = 'white'
+    ctx.fillRect(0, 0, canvasWidth, canvasHeight)
+    
+    // Draw images in grid layout - no centering needed since all are 1024x1024
+    images.forEach((image, index) => {
+        const col = index % cols
+        const row = Math.floor(index / cols)
+        
+        const x = col * cellSize
+        const y = row * cellSize
+        
+        ctx.drawImage(image, x, y)
+    })
+    
+    // Convert canvas to buffer
+    const buffer = canvas.toBuffer('image/png')
+    
+    return {
+        blob: new Blob([buffer], { type: 'image/png' }),
+        filename: 'merged_image.png'
     }
 }

--- a/src/services/imageService.js
+++ b/src/services/imageService.js
@@ -69,6 +69,21 @@ export async function generateImage(fetchParams, userId, res) {
 
     try {
       const result = await handler({ fetchParams, userId })
+
+      // TESTING TODO REMOVE
+/*       const arrayBuffer = await fetchParams.image.blob.arrayBuffer()
+      const base64Data = Buffer.from(arrayBuffer).toString('base64')
+      const result = {
+        created: Math.floor(Date.now() / 1000),
+        data: [{
+          b64_json: base64Data,
+          revised_prompt: 'test',
+        }]
+      } */
+
+
+
+      
       result.latency = Date.now() - startTime
       if (intervalId) clearInterval(intervalId)
       return result

--- a/src/shared/imageModels/black-forest-labs/flux-kontext-pro.js
+++ b/src/shared/imageModels/black-forest-labs/flux-kontext-pro.js
@@ -1,5 +1,5 @@
 import { PRICING_TYPES } from '../../PricingScheme.js'
-import { processSingleFile } from '../../../services/imageHelpers.js'
+import { processSingleFile, mergeImages } from '../../../services/imageHelpers.js'
 
 class FluxKontextPro {
   constructor() {
@@ -29,7 +29,11 @@ class FluxKontextPro {
   }
 
   async applyImage(params) {
-    params.image = await processSingleFile(params.files.image)
+    // Since Flux only accepts 1 input image, merge multiple images if provided
+    if (params.files.image.length > 1) {
+      params.prompt = 'system: merge all images into a single picture seamlessly\n\nuser: ' + params.prompt
+    }
+    params.image = await mergeImages(params.files.image)
     delete params.files.image
     return params
   }


### PR DESCRIPTION
I tried to force Flux-Kontext to take more than 1 image inputs.
### It's kinda okay with 2:
![image](https://github.com/user-attachments/assets/8bf710e7-ef2f-43cc-95b2-cfce48f24384)
![flux-kontext-pro-2025-05-31T22-05-06-229Z](https://github.com/user-attachments/assets/95037efe-10a4-4666-b216-86ad2b67a74c)

![image](https://github.com/user-attachments/assets/96bffec9-f99c-427c-b10e-19e029aae516)
![flux-kontext-pro-2025-05-31T22-06-18-265Z](https://github.com/user-attachments/assets/b515090d-cfce-4824-91cf-6390d1f1f7bc)

![image](https://github.com/user-attachments/assets/1b7ebfa1-d268-4853-8c5a-9ed2bc23835e)
![flux-kontext-pro-2025-05-31T22-11-43-337Z](https://github.com/user-attachments/assets/c095d99f-1679-454f-9a87-c52798e87c54)

### But it's weird with 3 or more:
![image](https://github.com/user-attachments/assets/9f0a106a-4469-4d84-a9a8-97892ff7416e)
![image](https://github.com/user-attachments/assets/96acb994-5ebb-491b-b68c-3b1e02e6368f)

![image](https://github.com/user-attachments/assets/e914c693-ef3e-4017-8fcb-6f9cdc105adc)
![image](https://github.com/user-attachments/assets/7fcfb93e-9d92-4e86-a2d3-0acc1837fa3d)

![image](https://github.com/user-attachments/assets/64d5aee5-db3c-43b9-a554-97470e0ea66d)
![image](https://github.com/user-attachments/assets/82a927ec-ae8e-42f9-ab5c-17de579f07ff)

![image](https://github.com/user-attachments/assets/57952431-dea1-45d7-bc2b-a41982030b08)
![image](https://github.com/user-attachments/assets/0b99dc1a-d15d-4dad-a32a-07d1e606ea00)

![image](https://github.com/user-attachments/assets/222b6d8d-92a1-4473-bc79-023ed72eb0e1)
![image](https://github.com/user-attachments/assets/94917bbf-8baa-4623-9c17-0ce30f5c97a2)

