### PR TITLE
add `response_format` and S3 storage support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_LOCATION=us-central1
 # Service Account Key (required) - base64 encoded JSON
 GOOGLE_SERVICE_ACCOUNT_KEY=
 
-
 # Optional authentication settings
 # Leave blank to disable charging
 
@@ -46,6 +45,17 @@ JWT_SECRET=
 
 # Webshare proxy settings for Gemini Flash
 PROXY_URL=http://proxyUsername:proxyPassword@proxyHost:proxyPort
+
+# S3 Storage Configuration (Backblaze B2, AWS S3, etc.)
+# Leave blank to disable storage - content will use original provider URLs
+# All files are private and accessed through secure proxy only
+S3_ACCESS_KEY_ID=
+S3_SECRET_ACCESS_KEY=
+S3_BUCKET_NAME=ImageRouter
+S3_REGION=us-east-005
+S3_ENDPOINT=https://s3.us-east-005.backblazeb2.com
+# Setup Cloudflare caching for BackBlaze image storage: https://www.backblaze.com/docs/cloud-storage-deliver-public-backblaze-b2-content-through-cloudflare-cdn
+S3_CUSTOM_PUBLIC_URL=https://storage-TEST.imagerouter.io
 
 # This is only required to run tests
 TEST_USER_API_KEY=

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "https-proxy-agent": "^5.0.1",
     "jest": "^29.7.0",
     "multer": "2.0.1",
-    "google-auth-library": "^9.0.0"
+    "google-auth-library": "^9.0.0",
+    "@aws-sdk/client-s3": "^3.450.0",
+    "@aws-sdk/lib-storage": "^3.450.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.3",

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import { videoModels } from './shared/videoModels/index.js'
 import { validateApiKey } from './middleware/apiKeyMiddleware.js'
 import { prisma } from './config/database.js'
 import { getGeminiApiKey } from './services/imageHelpers.js'
+import { storageService } from './services/storageService.js'
 
 dotenv.config()
 

--- a/src/routes/imageRoutes.js
+++ b/src/routes/imageRoutes.js
@@ -84,7 +84,7 @@ async function generateImageWrapper(req, res) {
             let imageResult
             try {
                 let fetchParams = structuredClone(params) // prevent side effects
-                imageResult = await generateImage(fetchParams, apiKey.user.id, res)
+                imageResult = await generateImage(fetchParams, apiKey.user.id, res, usageLogEntry.id)
             } catch (error) {
                 const errorToLog = error?.errorResponse?.message || error?.message || 'unknown error'
                 await refundUsage(apiKey, usageLogEntry, errorToLog)

--- a/src/routes/videoRoutes.js
+++ b/src/routes/videoRoutes.js
@@ -20,7 +20,7 @@ async function generateVideoWrapper(req, res) {
             let videoResult
             try {
                 let fetchParams = structuredClone(params) // prevent side effects
-                videoResult = await generateVideo(fetchParams, apiKey.user.id, res)
+                videoResult = await generateVideo(fetchParams, apiKey.user.id, res, usageLogEntry.id)
             } catch (error) {
                 const errorToLog = error?.errorResponse?.message || error?.message || 'unknown error'
                 await refundUsage(apiKey, usageLogEntry, errorToLog)

--- a/src/services/storageService.js
+++ b/src/services/storageService.js
@@ -1,0 +1,241 @@
+import { S3Client } from '@aws-sdk/client-s3'
+import { Upload } from '@aws-sdk/lib-storage'
+import fetch from 'node-fetch'
+
+class StorageService {
+    constructor() {
+        this.s3Client = null
+        this.bucketName = process.env.S3_BUCKET_NAME
+        this.region = process.env.S3_REGION
+        this.endpoint = process.env.S3_ENDPOINT
+        this.publicUrl = process.env.S3_CUSTOM_PUBLIC_URL
+        
+        this.initializeS3Client()
+    }
+
+    initializeS3Client() {
+        if (!process.env.S3_ACCESS_KEY_ID || !process.env.S3_SECRET_ACCESS_KEY) {
+            console.warn('S3 credentials not provided. Storage service will be disabled.')
+            return
+        }
+
+        const config = {
+            region: this.region,
+            credentials: {
+                accessKeyId: process.env.S3_ACCESS_KEY_ID,
+                secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
+            },
+            requestChecksumCalculation: 'WHEN_REQUIRED', // backblaze b2 doesn't support checksums
+            responseChecksumValidation: 'WHEN_REQUIRED', // backblaze b2 doesn't support checksums
+            useAccelerateEndpoint: false,
+            useGlobalEndpoint: false
+        }
+
+        if (this.endpoint) {
+            config.endpoint = this.endpoint
+            config.forcePathStyle = true
+        }
+
+        this.s3Client = new S3Client(config)
+    }
+
+    isEnabled() {
+        return this.s3Client !== null && this.bucketName && this.region
+    }
+
+    generateFileName(contentType, usageLogId) {
+        if (!usageLogId) {
+            throw new Error('usageLogId is required for file naming')
+        }
+        const extension = this.getExtensionFromContentType(contentType)
+        return `${usageLogId}${extension}`
+    }
+
+    getExtensionFromContentType(contentType) {
+        const typeMap = {
+            'image/jpeg': '.jpg',
+            'image/png': '.png',
+            'image/webp': '.webp',
+            'image/gif': '.gif',
+            'video/mp4': '.mp4',
+            'video/webm': '.webm',
+            'video/quicktime': '.mov'
+        }
+        return typeMap[contentType] || ''
+    }
+
+    async _uploadBuffer(buffer, contentType, usageLogId) {
+        const fileName = this.generateFileName(contentType, usageLogId)
+        const uploadParams = {
+            Bucket: this.bucketName,
+            Key: fileName,
+            Body: buffer,
+            ContentType: contentType,
+            ACL: 'public-read'
+        }
+        const upload = new Upload({
+            client: this.s3Client,
+            params: uploadParams
+        })
+        await upload.done()
+        const publicUrl = this.publicUrl
+            ? `${this.publicUrl}/${fileName}`
+            : `${this.endpoint}/${this.bucketName}/${fileName}`
+        return {
+            success: true,
+            url: publicUrl,
+            buffer: buffer
+        }
+    }
+
+    async downloadAndUpload(url, contentType, usageLogId) {
+        if (!this.isEnabled()) {
+            throw new Error('Storage service is not configured')
+        }
+
+        try {
+            const response = await fetch(url)
+            if (!response.ok) {
+                throw new Error(`Failed to download content: ${response.statusText}`)
+            }
+
+            const buffer = await response.buffer()
+            return await this._uploadBuffer(buffer, contentType, usageLogId)
+        } catch (error) {
+            console.error('Storage upload error:', error)
+            throw new Error(`Failed to upload to storage: ${error.message}`)
+        }
+    }
+
+    async uploadBase64(base64Data, contentType, usageLogId) {
+        if (!this.isEnabled()) {
+            throw new Error('Storage service is not configured')
+        }
+
+        try {
+            const base64Content = base64Data.replace(/^data:[^;]+;base64,/, '')
+            if (!base64Content) {
+                throw new Error('Invalid base64 data: empty content')
+            }
+            const buffer = Buffer.from(base64Content, 'base64')
+            return await this._uploadBuffer(buffer, contentType, usageLogId)
+        } catch (error) {
+            console.error('Storage upload error:', error)
+            throw new Error(`Failed to upload base64 to storage: ${error.message}`)
+        }
+    }
+
+    async processContent(content, responseFormat = 'url', usageLogId) {
+        if (!this.isEnabled()) {
+            return content
+        }
+
+        try {
+            if (!content.url && !content.b64_json) {
+                return content
+            }
+
+            let uploadResult
+
+            if (content.url) {
+                const contentType = this.detectContentType(content.url)
+                uploadResult = await this.downloadAndUpload(content.url, contentType, usageLogId)
+            } else if (content.b64_json) {  
+                const contentType = this.detectContentTypeFromBase64(content.b64_json)
+                uploadResult = await this.uploadBase64(content.b64_json, contentType, usageLogId)
+            }
+
+            if (responseFormat === 'b64_json') {
+                // Use the buffer from upload result instead of re-downloading
+                const base64Data = uploadResult.buffer ? uploadResult.buffer.toString('base64') : content.b64_json
+                const result = {
+                    ...content,
+                    b64_json: base64Data
+                }
+                delete result.url
+                return result
+            } else {
+                const result = {
+                    ...content,
+                    url: uploadResult.url
+                }
+                delete result.b64_json
+                return result
+            }
+        } catch (error) {
+            console.error('Content processing error:', error)
+            // Return original content as fallback
+            return content
+        }
+    }
+
+    detectContentType(url) {
+        const urlLower = url.toLowerCase()
+        
+        // Video formats
+        if (urlLower.includes('.mp4')) return 'video/mp4'
+        if (urlLower.includes('.webm')) return 'video/webm'
+        if (urlLower.includes('.mov') || urlLower.includes('.quicktime')) return 'video/quicktime'
+        if (urlLower.includes('.avi')) return 'video/avi'
+        
+        // Image formats
+        if (urlLower.includes('.png')) return 'image/png'
+        if (urlLower.includes('.jpg') || urlLower.includes('.jpeg')) return 'image/jpeg'
+        if (urlLower.includes('.webp')) return 'image/webp'
+        if (urlLower.includes('.gif')) return 'image/gif'
+        if (urlLower.includes('.svg')) return 'image/svg+xml'
+        
+        // Fallback based on context
+        if (urlLower.includes('video')) return 'video/mp4'
+        return 'image/png'
+    }
+
+    detectContentTypeFromBase64(base64Data) {
+        if (base64Data.startsWith('data:')) {
+            const match = base64Data.match(/^data:([^;]+);base64,/)
+            if (match) return match[1]
+        }
+        
+        const header = base64Data.substring(0, 20)
+        if (header.startsWith('/9j/')) return 'image/jpeg'
+        if (header.startsWith('iVBOR')) return 'image/png'
+        if (header.startsWith('UklGR')) return 'image/webp'
+        if (header.startsWith('R0lGOD')) return 'image/gif'
+        
+        return 'image/jpeg'
+    }
+
+    async processImageResult(result, userId, responseFormat = 'url', usageLogId) {
+        if (!result || !result.data) return result
+
+        const processedData = await Promise.all(
+            result.data.map(async (item, index) => {
+                const itemUsageLogId = result.data.length > 1 ? `${usageLogId}-${index}` : usageLogId
+                return await this.processContent(item, responseFormat, itemUsageLogId)
+            })
+        )
+
+        return {
+            ...result,
+            data: processedData
+        }
+    }
+
+    async processVideoResult(result, userId, responseFormat = 'url', usageLogId) {
+        if (!result || !result.data) return result
+
+        const processedData = await Promise.all(
+            result.data.map(async (item, index) => {
+                const itemUsageLogId = result.data.length > 1 ? `${usageLogId}-${index}` : usageLogId
+                return await this.processContent(item, responseFormat, itemUsageLogId)
+            })
+        )
+
+        return {
+            ...result,
+            data: processedData
+        }
+    }
+}
+
+export const storageService = new StorageService() 

--- a/src/services/validateImageParams.js
+++ b/src/services/validateImageParams.js
@@ -13,9 +13,10 @@ export function validateImageParams(req) {
     if (!modelConfig) throw new Error("model '" + model + "' is not available")
     if (!modelConfig?.providers[0].id) throw new Error("model provider for '" + model + "' is not available")
 
-    // Validate response_format parameter
-    if (response_format) {
-        throw new Error("'response_format' is not yet supported. Depending on the model, you'll get a base64 encoded image or a url to the image, but it cannot be changed now.")
+    // Set default response_format and validate
+    const validResponseFormat = response_format || 'url'
+    if (!['url', 'b64_json'].includes(validResponseFormat)) {
+        throw new Error("'response_format' must be either 'url' or 'b64_json'")
     }
     if (size) {
         throw new Error("'size' is not yet supported.")
@@ -47,5 +48,5 @@ export function validateImageParams(req) {
         validFiles.mask = files.mask
     }
 
-    return { prompt, model, quality: qualityLower, files: validFiles }
+    return { prompt, model, response_format: validResponseFormat, quality: qualityLower, files: validFiles }
 }

--- a/src/services/validateVideoParams.js
+++ b/src/services/validateVideoParams.js
@@ -12,9 +12,10 @@ export function validateVideoParams(req) {
     if (!modelConfig) throw new Error("model '" + model + "' is not available")
     if (!modelConfig?.providers[0].id) throw new Error("model provider for '" + model + "' is not available")
 
-    // Validate response_format parameter
-    if (response_format) {
-        throw new Error("'response_format' is not yet supported. You'll get a url to the video.")
+    // Set default response_format and validate
+    const validResponseFormat = response_format || 'url'
+    if (!['url', 'b64_json'].includes(validResponseFormat)) {
+        throw new Error("'response_format' must be either 'url' or 'b64_json'")
     }
     if (size) {
         throw new Error("'size' is not yet supported.")
@@ -25,5 +26,5 @@ export function validateVideoParams(req) {
         throw new Error("'quality' is not yet supported.")
     }
 
-    return { prompt, model }
+    return { prompt, model, response_format: validResponseFormat }
 } 


### PR DESCRIPTION
### Adds support for response_format parameter
Images are now stored on S3 so URLs can be returned even if the provider provides a base64_json response.


![image](https://github.com/user-attachments/assets/95571236-eecd-4653-b171-fa2a44508b11)
