### PR TITLE
feat: optimize SKILL.md score (56% → 85%) + add Tessl review action

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,44 +1,54 @@
 ---
-name: imagerouter
-description: Generate Images with any AI model on ImageRouter (requires API key).
+name: image-router
+description: "Generate, edit, and transform images via the ImageRouter API using any supported AI model. Supports text-to-image, image-to-image, inpainting with masks, and multi-image composition. Use when the user asks to create images, generate AI art, convert or stylize photos, produce illustrations, or work with ImageRouter models. Requires IMAGEROUTER_API_KEY."
 homepage: https://imagerouter.io
-metadata: {"openclaw":{"emoji":"🎨","requires":{"bins":["curl"]},"primaryEnv":"IMAGEROUTER_API_KEY"}}
+metadata:
+  version: "1.0.0"
+  openclaw_emoji: "🎨"
+  openclaw_requires_bins: "curl"
+  openclaw_primary_env: "IMAGEROUTER_API_KEY"
+triggers:
+  - generate image
+  - create image
+  - AI art
+  - text-to-image
+  - image-to-image
+  - ImageRouter
+  - produce illustration
+  - stylize photo
+  - inpainting
+  - image generation
+user-invocable: true
 ---
 
-# [ImageRouter](https://imagerouter.io) AI Image Generation
+# ImageRouter AI Image Generation
 
-Generate images with any AI model available on [ImageRouter](https://imagerouter.io).
+Generate, edit, and transform images with any AI model available on [ImageRouter](https://imagerouter.io). Supports text-to-image creation, image-to-image transformation, inpainting with masks, and multi-image composition (up to 16 inputs).
 
-## OpenClaw Setup
+## Setup
 
-- This skill expects your ImageRouter key in the environment variable `IMAGEROUTER_API_KEY`.
-- **Do not paste API keys into chat**. Set the env var in the OpenClaw Gateway environment (in terminal) and restart the gateway. Example:
+1. Set the `IMAGEROUTER_API_KEY` environment variable. **Do not paste API keys into chat.**
+2. For OpenClaw Gateway users, configure and restart:
 ```bash
 openclaw config set skills.entries.imagerouter.apiKey "your_api_key_here"
 openclaw gateway restart
 ```
+3. Get an API key at https://imagerouter.io/api-keys
 
-## Available models
-The `test/test` model is a free dummy model that is used for testing the API. It is not a real model, therefore you should use other models for image generation.
+## Discover Models
 
-Get top 10 most popular models:
+Find a model before generating. The `test/test` model is a free dummy for testing only — use a real model for actual generation.
+
 ```bash
+# Top 10 most popular models
 curl -X POST 'https://backend.imagerouter.io/operations/get-popular-models'
-```
 
-Search available models by name:
-```bash
+# Search models by name
 curl "https://api.imagerouter.io/v1/models?type=image&sort=date&name=gemini"
 ```
 
-Get all available models:
-```bash
-curl "https://api.imagerouter.io/v1/models?type=image&sort=date&limit=1000"
-```
+## Text-to-Image (Quick Start)
 
-## Quick Start - Text-to-Image
-
-Basic generation with JSON endpoint:
 ```bash
 curl 'https://api.imagerouter.io/v1/openai/images/generations' \
   -H "Authorization: Bearer $IMAGEROUTER_API_KEY" \
@@ -52,21 +62,13 @@ curl 'https://api.imagerouter.io/v1/openai/images/generations' \
   }'
 ```
 
-## Unified Endpoint (Text-to-Image & Image-to-Image)
+**Verify success:** Check that the response contains `"data"` with a `"url"` field. A missing or empty `"data"` array indicates an error.
 
-### Text-to-Image with multipart/form-data:
-```bash
-curl 'https://api.imagerouter.io/v1/openai/images/edits' \
-  -H "Authorization: Bearer $IMAGEROUTER_API_KEY" \
-  -F 'prompt=a cyberpunk city at night' \
-  -F 'model=test/test' \
-  -F 'quality=high' \
-  -F 'size=1024x1024' \
-  -F 'response_format=url' \
-  -F 'output_format=webp'
-```
+## Image-to-Image (Unified Endpoint)
 
-### Image-to-Image (with input images):
+The `/v1/openai/images/edits` endpoint handles both text-to-image and image-to-image via `multipart/form-data`. Use it when file uploads are needed.
+
+### Transform an existing image:
 ```bash
 curl 'https://api.imagerouter.io/v1/openai/images/edits' \
   -H "Authorization: Bearer $IMAGEROUTER_API_KEY" \
@@ -79,7 +81,7 @@ curl 'https://api.imagerouter.io/v1/openai/images/edits' \
   -F 'image[]=@/path/to/your/image.webp'
 ```
 
-### Multiple images (up to 16):
+### Compose multiple images (up to 16):
 ```bash
 curl 'https://api.imagerouter.io/v1/openai/images/edits' \
   -H "Authorization: Bearer $IMAGEROUTER_API_KEY" \
@@ -90,7 +92,7 @@ curl 'https://api.imagerouter.io/v1/openai/images/edits' \
   -F 'image[]=@image3.webp'
 ```
 
-### With mask (some models require mask for inpainting):
+### Inpainting with mask:
 ```bash
 curl 'https://api.imagerouter.io/v1/openai/images/edits' \
   -H "Authorization: Bearer $IMAGEROUTER_API_KEY" \
@@ -102,17 +104,16 @@ curl 'https://api.imagerouter.io/v1/openai/images/edits' \
 
 ## Parameters
 
-- **model** (required): Image model to use (see https://imagerouter.io/models)
-- **prompt** (optional): Text description for generation. Most models require a text prompt, but not all.
-- **quality** (optional): `auto` (default), `low`, `medium`, `high`
-- **size** (optional): `auto` (default) or `WIDTHxHEIGHT` (e.g., `1024x1024`).
-- **response_format** (optional): 
-  - `url` (default) - Returns hosted URL
-  - `b64_json` - Returns base64-encoded image
-  - `b64_ephemeral` - Base64 without saving to logs
-- **output_format** (optional): `webp` (default), `jpeg`, `png`
-- **image[]** (optional): Input file for Image-to-Image (multipart only)
-- **mask[]** (optional): Editing mask for inpainting (multipart only)
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `model` | Yes | — | Model ID (browse at https://imagerouter.io/models) |
+| `prompt` | No | — | Text description; most models require it |
+| `quality` | No | `auto` | `low`, `medium`, `high`, or `auto` |
+| `size` | No | `auto` | `auto` or `WIDTHxHEIGHT` (e.g., `1024x1024`) |
+| `response_format` | No | `url` | `url`, `b64_json`, or `b64_ephemeral` |
+| `output_format` | No | `webp` | `webp`, `jpeg`, or `png` |
+| `image[]` | No | — | Input file(s) for image-to-image (multipart only) |
+| `mask[]` | No | — | Mask file for inpainting (multipart only) |
 
 ## Response Format
 
@@ -129,32 +130,27 @@ curl 'https://api.imagerouter.io/v1/openai/images/edits' \
 }
 ```
 
+## Error Handling
+
+| HTTP Status | Cause | Fix |
+|-------------|-------|-----|
+| 401 | Invalid or missing API key | Verify `IMAGEROUTER_API_KEY` is set correctly |
+| 400 | Bad request (missing model, invalid params) | Check required `model` field and parameter values |
+| 429 | Rate limit exceeded | Wait and retry with exponential backoff |
+| 5xx | Server error | Retry after a short delay; check https://status.imagerouter.io if persistent |
+
 ## Endpoint Comparison
 
-| Feature | Unified (/edits) | JSON (/generations) |
-|---------|------------------|---------------------|
-| Text-to-Image | ✅ | ✅ |
-| Image-to-Image | ✅ | ❌ |
+| Feature | `/edits` (unified) | `/generations` (JSON) |
+|---------|--------------------|-----------------------|
+| Text-to-Image | Yes | Yes |
+| Image-to-Image | Yes | No |
 | Encoding | multipart/form-data | application/json |
 
-## Tips
+Use `/generations` for simple text-to-image without file uploads. Use `/edits` when image inputs or masks are needed.
 
-- Both `/v1/openai/images/generations` and `/v1/openai/images/edits` are the same for the unified endpoint
-- Use JSON endpoint for simple text-to-image when you don't need file uploads
-- Use unified endpoint when you need Image-to-Image capabilities
-- Check model features at https://imagerouter.io/models (quality support, edit support, etc.)
-- Get your API key at https://imagerouter.io/api-keys
+## Download Generated Image
 
-## Examples by Use Case
-
-### Quick test generation:
-```bash
-curl 'https://api.imagerouter.io/v1/openai/images/generations' \
-  -H "Authorization: Bearer $IMAGEROUTER_API_KEY" \
-  --json '{"prompt":"test image","model":"test/test"}'
-```
-
-### Download image directly:
 ```bash
 curl 'https://api.imagerouter.io/v1/openai/images/generations' \
   -H "Authorization: Bearer $IMAGEROUTER_API_KEY" \


### PR DESCRIPTION
Hey @DaWe35 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| image-router | 56% | 85% | +29% |

This PR covers your 1 skill in the repo.

<details>
<summary>What changed in image-router</summary>

- **Description rewritten** with concrete action verbs, an explicit "Use when..." clause listing trigger scenarios (create images, generate AI art, stylize photos, inpainting, etc.), and specific capability listing (text-to-image, image-to-image, multi-image composition, masks)
- **Added `user-invocable: true`** and **`triggers`** array with 10 natural trigger terms for frontmatter compliance
- **Fixed skill name** to kebab-case (`imagerouter` → `image-router`) and flattened `metadata` to string key-value pairs with `version` field
- **Restructured content** — clearer setup steps, dedicated model discovery section, parameters as a scannable table instead of a bullet list
- **Added error handling table** with HTTP status codes, causes, and fixes (401, 400, 429, 5xx)
- **Removed redundant Tips section** and duplicate quick-test example that restated content already demonstrated above

</details>

## Tessl Skill Review GitHub Action ✅

I've also included a GitHub Action (`.github/workflows/skill-review.yml`) that automatically reviews any `SKILL.md` changed in future PRs and posts scores as a PR comment.

**What this gives you:**
- 🔍 Automatic `tessl skill review` runs on every PR touching `SKILL.md`
- 💬 One updated PR comment with scores and improvement feedback
- 🔓 **Zero extra accounts** — contributors don't need a Tessl login; only `GITHUB_TOKEN` is used
- ✅ **Non-blocking by default** — feedback-only, no surprise red CI (add `fail-threshold: 70` later if you want a hard gate)
- 📈 Covers future skills incrementally as contributors edit them

## Want automatic AI optimization on every SKILL.md change? 🚀

The action I've added gives you **review scores** on PRs. We also have a more powerful variant — [`tesslio/skill-review-and-optimize`](https://github.com/tesslio/skill-review-and-optimize) — that can:

- Run **AI-powered optimization suggestions** on every `SKILL.md` PR (requires adding `TESSL_API_TOKEN` as a repo secret)
- Let contributors accept suggested improvements by commenting **`/apply-optimize`**
- Still works in review-only mode with zero secrets

Interested? Tick the box and I'll raise a follow-up PR:

- [ ] **Yes please!** Add the `tesslio/skill-review-and-optimize` action so every SKILL.md PR gets AI optimization suggestions + the `/apply-optimize` flow
- [ ] **No thanks** — the review scores action is enough for now

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch — just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me — [@rohan-tessl](https://github.com/rohan-tessl) — if you hit any snags.

Thanks in advance 🙏
